### PR TITLE
Add pathPrefix to /gryphon-doorknob

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,6 @@
 module.exports = {
+  pathPrefix: `/gryphon-doorknob`,
+
   siteMetadata: {
     title: `University of Guelph`,
     description: `The University of Guelph, and everyone who studies here, explores here, teaches here and works here is committed to one simple purpose: To Improve Life.`,


### PR DESCRIPTION
Adding pathPrefix option that allows us to build site at /gryphon-doorknob

It will only build the site in this manner if we run:

gatsby build --prefix-paths

Otherwise it will build it as normal (without /gryphon-doorknob as the path prefix for all the images, web components, etc.)