### PR TITLE
Add environment variables for Azure DevOps pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,9 @@ schedules:
   always: true
 
 variables:
-  _path_prefix: '$(PathPrefix)'
-  - group: ug-doorknob
+- group: ug-doorknob
+- name: _path_prefix
+  value: '$(PathPrefix)'
 
 pool:
   vmImage: ubuntu-latest


### PR DESCRIPTION
Added a variable group so the Gatsby build will run on Azure DevOps. 

Pipeline now works on main org and Avalon. (Was previously broken.)