### PR TITLE
Use spotlight title instead of link title for cards

### DIFF
--- a/src/hooks/drupal/use-spotlight-data.js
+++ b/src/hooks/drupal/use-spotlight-data.js
@@ -68,6 +68,7 @@ export const useSpotlightData = () => {
           edges {
             node {
               drupal_id
+              title
               field_spotlight_image_alignment
               field_spotlight_rank
               field_spotlight_url {


### PR DESCRIPTION
# Summary of changes
Use spotlight title instead of link title for cards

## Frontend
Use spotlight title instead of link title for cards

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
None

# Test Plan

- Ensure spotlight title instead of link text title is showing on the homepage. May have to test locally when pointing to a multidev to confirm.