### PR TITLE
Netlify optimizations: Add api-key and disallow build_hooks link type

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -130,7 +130,7 @@ module.exports = {
             `taxonomy_vocabulary--taxonomy_vocabulary`,
         ],
         skipFileDownloads: true,
-        requestTimeoutMS: 300000,
+        requestTimeoutMS: 360000,
       },
     },
     {


### PR DESCRIPTION
# Summary of changes
Optimize the build to better use Netlify for previews

## Frontend
- Add `api-key` and associated environment variable (recommended by Gatsby, more secure and reliable than `basic_auth` which can eventually be removed)
- Prevent `gatsby-source-drupal` from pulling in the build_hooks link type (this build only needs `node--spotlight` and image files)

[ x ] My changes are accessible (at minimum WCAG 2.0 Level AA)
[ x ] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
- Add `Doorknob Preview` frontend environment
- Grant `Spotlight Editor` role the ability to trigger deployments

# Test Plan

Drupal backend: https://netlify-chug.pantheonsite.io/admin/build_hooks/deployments/doorknob_preview
Netlify preview build: https://deploy-preview-47--doorknob.netlify.app/

- Go to https://netlify-chug.pantheonsite.io/admin/build_hooks/deployments/doorknob_preview and trigger a deployment
- Verify it completed successfully and the page appears as expected

**NOTE:** prior to merging, ensure the `api-key` is added as an environment variable to the Azure production build.