### PR TITLE
Ulrawide hero fix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "arrowParens": "avoid",
-  "semi": false,
+  "semi": true,
   "printWidth": 120
 }

--- a/src/hooks/drupal/use-spotlight-data.js
+++ b/src/hooks/drupal/use-spotlight-data.js
@@ -1,18 +1,18 @@
-import { useStaticQuery, graphql } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby";
 
 function getLink(url) {
   // Assume internal URL by default
-  let spotlightLink = "https://www.uoguelph.ca" + url.url
+  let spotlightLink = "https://www.uoguelph.ca" + url.url;
 
   // Check if Spotlight URL is external
   if (url?.url === url?.uri) {
-    spotlightLink = url.url
+    spotlightLink = url.url;
   }
-  return spotlightLink
+  return spotlightLink;
 }
 
 export const useSpotlightData = () => {
-  let spotlightData = {}
+  let spotlightData = {};
 
   /* -------
   // hero
@@ -86,10 +86,10 @@ export const useSpotlightData = () => {
         }
       }
     }
-  `)
+  `);
 
-  const hero = data.hero
-  let heroData = []
+  const hero = data.hero;
+  let heroData = [];
 
   hero.edges.forEach(item => {
     heroData.push({
@@ -101,11 +101,11 @@ export const useSpotlightData = () => {
       captionText: item?.node?.field_spotlight_caption,
       title: item?.node?.title,
       url: getLink(item?.node?.field_spotlight_url),
-    })
-  })
+    });
+  });
 
-  const cards = data.cards
-  let cardsData = []
+  const cards = data.cards;
+  let cardsData = [];
 
   cards.edges.forEach(item => {
     cardsData.push({
@@ -115,16 +115,16 @@ export const useSpotlightData = () => {
       imageAlignment: item?.node?.field_spotlight_image_alignment,
       title: item?.node?.field_spotlight_url.title,
       url: getLink(item?.node?.field_spotlight_url),
-    })
-  })
+    });
+  });
 
   // Remove first item of array (a.k.a. the hero)
-  cardsData.shift()
+  cardsData.shift();
 
   spotlightData = {
     hero: heroData,
     cards: cardsData,
-  }
+  };
 
-  return spotlightData
-}
+  return spotlightData;
+};

--- a/src/hooks/drupal/use-spotlight-data.js
+++ b/src/hooks/drupal/use-spotlight-data.js
@@ -1,18 +1,18 @@
-import { useStaticQuery, graphql } from "gatsby";
+import { useStaticQuery, graphql } from "gatsby"
 
 function getLink(url) {
   // Assume internal URL by default
-  let spotlightLink = "https://www.uoguelph.ca" + url.url;
+  let spotlightLink = "https://www.uoguelph.ca" + url.url
 
   // Check if Spotlight URL is external
   if (url?.url === url?.uri) {
-    spotlightLink = url.url;
+    spotlightLink = url.url
   }
-  return spotlightLink;
+  return spotlightLink
 }
 
 export const useSpotlightData = () => {
-  let spotlightData = {};
+  let spotlightData = {}
 
   /* -------
   // hero
@@ -23,74 +23,61 @@ export const useSpotlightData = () => {
     // Rank 1 will be skipped since it's for the Hero image
     // Only a maxiumum of 4 published nodes will be returned
   --------- */
-  const data = useStaticQuery(
-    graphql`
-      query {
-        hero: allNodeSpotlight(
-          sort: {changed: DESC}
-          filter: {field_spotlight_rank: {eq: 1}}
-          limit: 1
-          ) {
-          edges {
-            node {
-              field_spotlight_alignment
-              field_spotlight_image_alignment
-              field_spotlight_button
-              field_spotlight_caption
-              field_spotlight_rank
-              field_spotlight_url {
-                uri
-                url
-                title
-              }
-              relationships {
-                field_hero_image {
+  const data = useStaticQuery(graphql`
+    query {
+      hero: allNodeSpotlight(sort: { changed: DESC }, filter: { field_spotlight_rank: { eq: 1 } }, limit: 1) {
+        edges {
+          node {
+            field_spotlight_alignment
+            field_spotlight_image_alignment
+            field_spotlight_button
+            field_spotlight_caption
+            field_spotlight_rank
+            field_spotlight_url {
+              uri
+              url
+              title
+            }
+            relationships {
+              field_hero_image {
+                field_media_image {
+                  alt
+                }
+                relationships {
                   field_media_image {
-                    alt
-                  }
-                  relationships {
-                    field_media_image {
-                      gatsbyImage(
-                        width: 1680
-                        height: 640
-                        formats: [AUTO, WEBP]
-                      )
-                    }
+                    gatsbyImage(width: 1680, height: 640, layout: FULL_WIDTH, formats: [AUTO, WEBP])
                   }
                 }
               }
-              drupal_id
-              title
             }
+            drupal_id
+            title
           }
         }
-        cards: allNodeSpotlight(
-          sort: [{field_spotlight_rank: ASC}, {changed: DESC}]
-          filter: {status: {eq: true}}
-          limit: 5
-        ) {
-          edges {
-            node {
-              drupal_id
-              field_spotlight_image_alignment
-              field_spotlight_rank
-              field_spotlight_url {
-                uri
-                url
-                title
-              }
-              relationships {
-                field_hero_image {
+      }
+      cards: allNodeSpotlight(
+        sort: [{ field_spotlight_rank: ASC }, { changed: DESC }]
+        filter: { status: { eq: true } }
+        limit: 5
+      ) {
+        edges {
+          node {
+            drupal_id
+            field_spotlight_image_alignment
+            field_spotlight_rank
+            field_spotlight_url {
+              uri
+              url
+              title
+            }
+            relationships {
+              field_hero_image {
+                field_media_image {
+                  alt
+                }
+                relationships {
                   field_media_image {
-                    alt
-                  }
-                  relationships {
-                    field_media_image {
-                      gatsbyImage(
-                        width: 640
-                        formats: [AUTO, WEBP]
-                      )
-                    }
+                    gatsbyImage(width: 640, formats: [AUTO, WEBP])
                   }
                 }
               }
@@ -98,12 +85,13 @@ export const useSpotlightData = () => {
           }
         }
       }
+    }
   `)
 
-  const hero = data.hero;
-  let heroData = [];
+  const hero = data.hero
+  let heroData = []
 
-  hero.edges.forEach((item) => {
+  hero.edges.forEach(item => {
     heroData.push({
       imageSrc: item?.node?.relationships.field_hero_image?.relationships.field_media_image.gatsbyImage,
       imageAlt: item?.node?.relationships.field_hero_image?.field_media_image.alt,
@@ -112,31 +100,31 @@ export const useSpotlightData = () => {
       captionAlign: item?.node?.field_spotlight_alignment,
       captionText: item?.node?.field_spotlight_caption,
       title: item?.node?.title,
-      url: getLink(item?.node?.field_spotlight_url)
+      url: getLink(item?.node?.field_spotlight_url),
     })
-  });
+  })
 
-  const cards = data.cards;
-  let cardsData = [];
+  const cards = data.cards
+  let cardsData = []
 
-  cards.edges.forEach((item) => {
+  cards.edges.forEach(item => {
     cardsData.push({
       key: item?.node?.drupal_id,
       imageSrc: item?.node?.relationships.field_hero_image?.relationships.field_media_image.gatsbyImage,
       imageAlt: item?.node?.relationships.field_hero_image?.field_media_image.alt,
       imageAlignment: item?.node?.field_spotlight_image_alignment,
       title: item?.node?.field_spotlight_url.title,
-      url: getLink(item?.node?.field_spotlight_url)
+      url: getLink(item?.node?.field_spotlight_url),
     })
-  });
+  })
 
   // Remove first item of array (a.k.a. the hero)
-  cardsData.shift();
+  cardsData.shift()
 
   spotlightData = {
     hero: heroData,
-    cards: cardsData
+    cards: cardsData,
   }
 
-  return spotlightData;
+  return spotlightData
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,7 +37,8 @@ h6,
   width: 66.666% !important;
 }
 
-#rotator img {
+#rotator .gatsby-image-wrapper {
+  max-height: 75vh;
   aspect-ratio: 5/3;
 }
 
@@ -184,13 +185,13 @@ h1 {
 }
 
 @media (min-width: 768px) {
-  #rotator img {
-    aspect-ratio: 21 / 9;
+  #rotator .gatsby-image-wrapper {
+    aspect-ratio: 16 / 9;
   }
 }
 
 @media (min-width: 992px) {
-  #rotator img {
+  #rotator .gatsby-image-wrapper {
     aspect-ratio: auto;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -188,6 +188,10 @@ h1 {
   #rotator .gatsby-image-wrapper {
     aspect-ratio: 16 / 9;
   }
+
+  .spotlight-hero-content {
+    max-width: unset;
+  }
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
# Summary of changes
Fixes the issue with the hero image being cutoff on the top and bottom on ultra wide displays. 

It does this by allowing the hero image to increase in height up to a certain limit (75% of the viewport).

The image still gets slightly cutoff on 2K ultra wide displays (3440 x 1440p) but significantly less than before. Even without the height limit the image doesn't fit within the viewport and users would have to scroll down to see the rest.

Here's a before and after example:

Before:
![Safari 2024-01-18 at 15 32 49](https://github.com/ccswbs/doorknob/assets/31970836/80397500-f3af-4925-a07c-6571f80ee7c7)

After
![Safari 2024-01-18 at 15 32 17](https://github.com/ccswbs/doorknob/assets/31970836/49d28fdc-ce88-4d61-87e8-a676e61a5e0b)


## Frontend
- Updated the graphql query for the hero image in useSpotlightData.js
- Updated the global styles to add a height limit and fix an issue with the hero caption on some breakpoints.

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
N/A

# Test Plan

1. View the home page
1. Test the page at various breakpoints: mobile, desktop, laptop, ultra wide, etc.
1. Ensure the hero image isn't cutoff (or at least extremely cutoff) at all breakpoints.