### PR TITLE
Change from unpkg to jsdelivr and use env variable for CDN base URL

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,23 +1,17 @@
-import React from "react"
-import Layout from "./src/components/layout"
+import React from "react";
+import Layout from "./src/components/layout";
 
 export const wrapPageElement = ({ element, props }) => {
-  return <Layout {...props}>{element}</Layout>
-}
+  return <Layout {...props}>{element}</Layout>;
+};
+
+const CDN_BASE = "https://cdn.jsdelivr.net/npm";
+const UOFG_WEB_COMPONENTS_BASE = "@uoguelph/web-components@1.x.x/dist/uofg-web-components";
 
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   setHeadComponents([
-    <link
-      rel="preconnect"
-      href="https://fonts.googleapis.com"
-      key="https://fonts.googleapis.com"
-    />,
-    <link
-      rel="preconnect"
-      href="https://fonts.gstatic.com"
-      key="https://fonts.gstatic.com"
-      crossOrigin="anonymous"
-    />,
+    <link rel="preconnect" href="https://fonts.googleapis.com" key="https://fonts.googleapis.com" />,
+    <link rel="preconnect" href="https://fonts.gstatic.com" key="https://fonts.gstatic.com" crossOrigin="anonymous" />,
     <link
       href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
       key="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
@@ -25,15 +19,15 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
     />,
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.css"
-      key="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.css"
+      href={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.css`}
+      key={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.css`}
     />,
     <script
       type="module"
-      src="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.esm.js"
-      key="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.esm.js"
+      src={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.esm.js`}
+      key={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.esm.js`}
     ></script>,
-  ])
+  ]);
   setPostBodyComponents([
     <script
       key="https://kit.fontawesome.com/7993323d0c.js"
@@ -41,5 +35,5 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
       crossOrigin="anonymous"
       defer
     />,
-  ])
-}
+  ]);
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,8 +5,10 @@ export const wrapPageElement = ({ element, props }) => {
   return <Layout {...props}>{element}</Layout>;
 };
 
-const CDN_BASE = "https://cdn.jsdelivr.net/npm";
-const UOFG_WEB_COMPONENTS_BASE = "@uoguelph/web-components@1.x.x/dist/uofg-web-components";
+const CDN_BASE = process.env.UOFG_WC_CDN_BASE_URL?.trim() || "https://cdn.jsdelivr.net/npm";
+const UOFG_WEB_COMPONENTS_BASE = `@uoguelph/web-components@${
+  process.env.UOFG_WC_VERSION?.trim() || "1.x.x"
+}/dist/uofg-web-components`;
 
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   setHeadComponents([


### PR DESCRIPTION
# Summary of changes
Changing the CDN we use to load the web components from unpkg to jsdelivr. Also added the ability to change the CDN using an env variable.

Rationale:

Earlier we had an issue with unpkg failing to load the web components causing the header and footer to not show up at all which is fine as CDN's sometime go down, but after looking through [unpkg's issue section on GitHub](https://github.com/mjackson/unpkg/issues/343), it seems many suggest ditching it entirely and using jsdelivr instead.

## Frontend
Updated gatsby-ssr.js to point to jsdelivr instead of unpkg

[ X ] My changes are accessible (at minimum WCAG 2.0 Level AA)
[ X ] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
N/A

# Test Plan

1. Go to the preview url
2. Ensure the header and footer load on the page