### PR TITLE
Fix Error 418

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,14 @@
 import React from "react"
+import ReactDOM from 'react-dom'
 import Layout from "./src/components/layout"
 
 export const wrapPageElement = ({ element, props }) => {
   return <Layout {...props}>{element}</Layout>
+}
+
+export const replaceHydrateFunction = () => {
+  return (element, container) => {
+    const root = ReactDOM.createRoot(container)
+    root.render(element)
+  }
 }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,5 @@
 import React from "react"
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom/client'
 import Layout from "./src/components/layout"
 
 export const wrapPageElement = ({ element, props }) => {


### PR DESCRIPTION
# Summary of changes
Fixes error 418 on the home page.

## Frontend
Added replaceHydrateFunction to gatsby-browser.js to fix hydration errors as mentioned in this discussion: https://github.com/gatsbyjs/gatsby/discussions/36232#discussioncomment-6145538

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
N/A

# Test Plan

1. Go to the home page: https://deploy-preview-54--doorknob.netlify.app/
2. Ensure page looks the same as live
3. Check developer console, and make sure no errors related to hydration or error 418 occur