### PR TITLE
Title and spotlight change

### DIFF
--- a/src/components/blocks/home/homeCardsSpotlight.js
+++ b/src/components/blocks/home/homeCardsSpotlight.js
@@ -32,7 +32,6 @@ export default function HomeCardsSpotlight() {
               "bg-info",
               "bg-opacity-10",
               "spotlight-card",
-              `spotlight-card-rank-${index + 2}`,
               { "left-align-image": imageAlignment === "left" },
               { "right-align-image": imageAlignment === "right" },
             );
@@ -45,7 +44,10 @@ export default function HomeCardsSpotlight() {
                     <Card.Title
                       as="a"
                       href={item.url}
-                      className="h5 spotlight link-dark stretched-link text-decoration-none fw-bold text-center"
+                      className={classNames(
+                        "h5 spotlight link-dark stretched-link text-decoration-none fw-bold text-center",
+                        `spotlight-card-rank-${index + 2}`,
+                      )}
                     >
                       {item.title}
                     </Card.Title>

--- a/src/components/blocks/home/homeCardsSpotlight.js
+++ b/src/components/blocks/home/homeCardsSpotlight.js
@@ -32,6 +32,7 @@ export default function HomeCardsSpotlight() {
               "bg-info",
               "bg-opacity-10",
               "spotlight-card",
+              `spotlight-card-rank-${index + 2}`,
               { "left-align-image": imageAlignment === "left" },
               { "right-align-image": imageAlignment === "right" },
             );
@@ -46,7 +47,7 @@ export default function HomeCardsSpotlight() {
                       href={item.url}
                       className={classNames(
                         "h5 spotlight link-dark stretched-link text-decoration-none fw-bold text-center",
-                        `spotlight-card-rank-${index + 2}`,
+                        `spotlight-rank-${index + 2}`,
                       )}
                     >
                       {item.title}

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -1,29 +1,25 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { Helmet } from 'react-helmet'
-import { StaticQuery, graphql } from 'gatsby'
+import React from "react";
+import PropTypes from "prop-types";
+import { Helmet } from "react-helmet";
+import { StaticQuery, graphql } from "gatsby";
 
 function Seo({ description, img, imgAlt, lang, meta, keywords, title }) {
-    
   let imgURL = img ? "https://cdn.uoguelph.ca" + img : ``;
-    
+
   return (
     <StaticQuery
       query={detailsQuery}
       render={data => {
-        const metaDescription =
-          description || data.site.siteMetadata.description	
-        const metaImage = 
-          imgURL || data.site.siteMetadata.ogImage
-        const metaImageAlt = 
-          imgAlt || data.site.siteMetadata.ogImageAlt
+        const metaDescription = description || data.site.siteMetadata.description;
+        const metaImage = imgURL || data.site.siteMetadata.ogImage;
+        const metaImageAlt = imgAlt || data.site.siteMetadata.ogImageAlt;
         return (
           <Helmet
             htmlAttributes={{
               lang,
             }}
-            title={title}
-            titleTemplate={`%s | ${data.site.siteMetadata.title}`}
+            title={title ?? "University of Guelph - Improve Life"}
+            titleTemplate={title ? `%s | ${data.site.siteMetadata.title}` : "%s"}
             meta={[
               {
                 name: `description`,
@@ -80,33 +76,33 @@ function Seo({ description, img, imgAlt, lang, meta, keywords, title }) {
                       name: `keywords`,
                       content: keywords.join(`, `),
                     }
-                  : []
+                  : [],
               )
               .concat(meta)}
           />
-        )
+        );
       }}
     />
-  )
+  );
 }
 
 Seo.defaultProps = {
   lang: `en`,
   meta: [],
   keywords: [],
-}
+};
 
 Seo.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.array,
   keywords: PropTypes.arrayOf(PropTypes.string),
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   img: PropTypes.string,
   imgAlt: PropTypes.string,
-}
+};
 
-export default Seo
+export default Seo;
 
 const detailsQuery = graphql`
   query DefaultSEOQuery {
@@ -120,4 +116,4 @@ const detailsQuery = graphql`
       }
     }
   }
-`
+`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,7 +28,7 @@ export default function Home({ data, children }) {
     <>
       <BECookieBar />
       <AppArmorAlert id="163" />
-      <Seo title="University of Guelph - Improve Life" description="Discover excellence at the University of Guelph - a leading institution fostering innovation, world-class research, and personalized learning. Explore our diverse academic programs, cutting-edge facilities, and vibrant campus life. Join a community dedicated to shaping the future." />
+      <Seo description="Discover excellence at the University of Guelph - a leading institution fostering innovation, world-class research, and personalized learning. Explore our diverse academic programs, cutting-edge facilities, and vibrant campus life. Join a community dedicated to shaping the future." />
       <h1 className="visually-hidden">University of Guelph, Ontario, Canada</h1>
       {renderHero}
       <HomeTagline />


### PR DESCRIPTION
# Summary of changes
Linda has asked me to change the homepages title from University of Guelph - Improve Life | University of Guelph to University of Guelph - Improve Life

Also I've added the unique class on spotlight cards to the a tag as well rather than just being on the div. This was done because we were still having trouble targeting the spotlights in GTM. 

## Frontend
- Changed seo.js to have a default title, and make title not required.
- Removed title from seo component on home page to allow for use of default title.
- Added unique class to spotlight a tag as well as wrapper div

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
N/A

# Test Plan

- Go to https://deploy-preview-58--doorknob.netlify.app/
- Ensure the title of the homepage is now University of Guelph - Improve Life instead of University of Guelph - Improve Life | University of Guelph
- Ensure each spotlight card has a unique class on its a tag
- Go to https://deploy-preview-58--doorknob.netlify.app/show-me-404
- Ensure the title is still 404: Not Found | University of Guelph