### PR TITLE
Correct typo in Maclean's ranking reference link

### DIFF
--- a/src/data/block/home-stats.yml
+++ b/src/data/block/home-stats.yml
@@ -10,7 +10,7 @@ stats:
   - field_statistic_represents: <a href="https://sustainabilitymag.com/sustainability/inside-the-worlds-most-sustainable-university">QS Sustainability Rankings, 2023</a>
     field_statistic_value: Top 10% for <strong>Sustainability</strong>
 
-  - field_statistic_represents: <a href="https://education.macleans.ca/feature/canadas-best-comprehensive-universities-rankings-2024/">Macleans, 2024</a>
+  - field_statistic_represents: <a href="https://education.macleans.ca/feature/canadas-best-comprehensive-universities-rankings-2024/">Maclean's, 2024</a>
     field_statistic_value: A <strong>Top Comprehensive University</strong> in Canada
 
   - field_statistic_represents: <a href="https://www.timeshighereducation.com/world-university-rankings/by-subject">Times Higher Education, 2023</a>


### PR DESCRIPTION
# Summary of changes
Fixing typo in home page statistics widget: Macleans to Maclean's

## Frontend
- update home-stats.yml to fix typo

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.

## Backend
N/A

# Test Plan

1. Go to https://deploy-preview-61--doorknob.netlify.app
2. Scroll down to the statistics
3. Ensure the type is fixed in the red card.